### PR TITLE
refactor: make the compiler work lazily

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,7 @@ dependencies = [
  "generational-arena",
  "lox-compile",
  "lox-ir",
+ "lox-lex",
  "salsa",
  "tracing",
 ]

--- a/components/lox-compile/src/compile.rs
+++ b/components/lox-compile/src/compile.rs
@@ -35,8 +35,10 @@ pub fn compile(db: &dyn crate::Db, function: lox_ir::function::Function) -> Comp
     } else {
         1
     };
-    let mut compiler = Compiler::default();
-    compiler.scope_depth = scope_depth;
+    let compiler = Compiler {
+        scope_depth,
+        ..Default::default()
+    };
     let compiler = Rc::new(RefCell::new(compiler));
 
     let mut chunk = Chunk::default();

--- a/components/lox-compile/src/lib.rs
+++ b/components/lox-compile/src/lib.rs
@@ -2,9 +2,10 @@
 
 pub mod compile;
 pub use compile::compile_file;
+pub mod prelude;
 
 #[salsa::jar(db = Db)]
-pub struct Jar(compile::compile_file);
+pub struct Jar(compile::compile_file, compile::compile);
 
 pub trait Db: salsa::DbWithJar<Jar> + lox_ir::Db + lox_parse::Db {}
 impl<T> Db for T where T: salsa::DbWithJar<Jar> + lox_ir::Db + lox_parse::Db {}

--- a/components/lox-compile/src/prelude.rs
+++ b/components/lox-compile/src/prelude.rs
@@ -1,0 +1,12 @@
+use crate::compile::compile;
+use lox_ir::bytecode::Closure;
+
+pub trait FunctionCompileExt {
+    fn compile(&self, db: &dyn crate::Db) -> Closure;
+}
+
+impl FunctionCompileExt for lox_ir::function::Function {
+    fn compile(&self, db: &dyn crate::Db) -> Closure {
+        compile(db, *self)
+    }
+}

--- a/components/lox-compile/src/prelude.rs
+++ b/components/lox-compile/src/prelude.rs
@@ -1,12 +1,13 @@
+use lox_ir::bytecode::CompiledFunction;
+
 use crate::compile::compile;
-use lox_ir::bytecode::Closure;
 
 pub trait FunctionCompileExt {
-    fn compile(&self, db: &dyn crate::Db) -> Closure;
+    fn compile(&self, db: &dyn crate::Db) -> CompiledFunction;
 }
 
 impl FunctionCompileExt for lox_ir::function::Function {
-    fn compile(&self, db: &dyn crate::Db) -> Closure {
+    fn compile(&self, db: &dyn crate::Db) -> CompiledFunction {
         compile(db, *self)
     }
 }

--- a/components/lox-execute/Cargo.toml
+++ b/components/lox-execute/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 salsa = { path="../salsa" }
 lox-ir = { path="../lox-ir" }
+lox-lex = { path="../lox-lex" }
 lox-compile = { path="../lox-compile" }
 tracing = "0.1.37"
 generational-arena = "0.2.9"

--- a/components/lox-execute/src/execute.rs
+++ b/components/lox-execute/src/execute.rs
@@ -1,4 +1,3 @@
-use lox_compile::prelude::FunctionCompileExt;
 use lox_ir::{bytecode, input_file::InputFile};
 
 use crate::vm::{ControlFlow, VM};
@@ -16,8 +15,7 @@ pub fn execute_file(
     step_inspect: Option<impl FnMut(Option<bytecode::Code>, &VM) + Clone>,
 ) -> String {
     let main = main_function(db, input_file.clone());
-    let function = main.compile(db);
-    let mut vm = VM::new(function);
+    let mut vm = VM::new(main, db);
 
     while let ControlFlow::Next = vm.step(db, step_inspect.clone()) {}
 

--- a/components/lox-execute/src/execute.rs
+++ b/components/lox-execute/src/execute.rs
@@ -14,7 +14,7 @@ pub fn execute_file(
     input_file: InputFile,
     step_inspect: Option<impl FnMut(Option<bytecode::Code>, &VM) + Clone>,
 ) -> String {
-    let main = main_function(db, input_file.clone());
+    let main = main_function(db, input_file);
     let mut vm = VM::new(main, db);
 
     while let ControlFlow::Next = vm.step(db, step_inspect.clone()) {}

--- a/components/lox-execute/src/execute.rs
+++ b/components/lox-execute/src/execute.rs
@@ -1,17 +1,25 @@
-use lox_compile::compile;
+use lox_compile::prelude::FunctionCompileExt;
 use lox_ir::{bytecode, input_file::InputFile};
 
 use crate::vm::{ControlFlow, VM};
+
+#[salsa::tracked]
+pub fn main_function(db: &dyn crate::Db, input_file: InputFile) -> lox_ir::function::Function {
+    let tree = lox_lex::lex_file(db, input_file);
+    let name = lox_ir::word::Word::new(db, "main".to_string());
+    lox_ir::function::Function::new(db, name, vec![], tree)
+}
 
 pub fn execute_file(
     db: &impl crate::Db,
     input_file: InputFile,
     step_inspect: Option<impl FnMut(Option<bytecode::Code>, &VM) + Clone>,
 ) -> String {
-    let function = compile::compile_file(db, input_file);
+    let main = main_function(db, input_file.clone());
+    let function = main.compile(db);
     let mut vm = VM::new(function);
 
-    while let ControlFlow::Next = vm.step(step_inspect.clone()) {}
+    while let ControlFlow::Next = vm.step(db, step_inspect.clone()) {}
 
     vm.output
 }

--- a/components/lox-execute/src/lib.rs
+++ b/components/lox-execute/src/lib.rs
@@ -7,7 +7,7 @@ pub use execute::execute_file;
 pub use vm::VM;
 
 #[salsa::jar(db = Db)]
-pub struct Jar();
+pub struct Jar(execute::main_function);
 
 pub trait Db: salsa::DbWithJar<Jar> + lox_ir::Db + lox_compile::Db {}
 impl<T> Db for T where T: salsa::DbWithJar<Jar> + lox_ir::Db + lox_compile::Db {}

--- a/components/lox-execute/src/vm.rs
+++ b/components/lox-execute/src/vm.rs
@@ -13,7 +13,6 @@ pub enum Value {
     Nil,
     String(String),
     Function(Function),
-    CompiledFunction(CompiledFunction),
 }
 
 impl std::fmt::Display for Value {
@@ -24,7 +23,6 @@ impl std::fmt::Display for Value {
             Value::Nil => write!(f, "nil"),
             Value::String(s) => write!(f, "{}", s),
             Value::Function(func) => write!(f, "<func {:?}>", func),
-            Value::CompiledFunction(func) => write!(f, "<compiled func {}>", &func.name),
         }
     }
 }
@@ -37,7 +35,6 @@ impl std::fmt::Debug for Value {
             Value::Nil => write!(f, "nil"),
             Value::String(s) => write!(f, "{}", s),
             Value::Function(func) => write!(f, "<func {:?}>", func),
-            Value::CompiledFunction(func) => write!(f, "<compiled func {}>", &func.name),
         }
     }
 }
@@ -191,15 +188,16 @@ pub struct VM {
 }
 
 impl VM {
-    pub fn new(main: CompiledFunction) -> Self {
+    pub fn new(main: Function, db: &dyn crate::Db) -> Self {
+        let function = main.compile(db);
         let frame = CallFrame {
-            function: main.clone(),
+            function,
             ip: 0,
             fp: 0,
         };
 
         let mut heap = generational_arena::Arena::new();
-        let index_of_main = heap.insert(Value::CompiledFunction(main));
+        let index_of_main = heap.insert(Value::Function(main));
         // push the value of the main function to the stack to a call to the main function,
         // making it is consistent with other function calls.
         let stack = vec![index_of_main];

--- a/components/lox-ir/src/bytecode.rs
+++ b/components/lox-ir/src/bytecode.rs
@@ -49,10 +49,7 @@ pub enum Code {
     Pop,
     JumpIfFalse(usize),
     Jump(usize),
-    Closure {
-        function: Function,
-        upvalues: Vec<Upvalue>,
-    },
+    Function(crate::function::Function),
     Call {
         arity: usize,
     },
@@ -99,4 +96,10 @@ pub struct Function {
     pub name: String,
     pub arity: usize,
     pub chunk: Chunk,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Default)]
+pub struct Closure {
+    pub function: Function,
+    pub upvalues: Vec<Upvalue>,
 }

--- a/components/lox-ir/src/bytecode.rs
+++ b/components/lox-ir/src/bytecode.rs
@@ -1,16 +1,4 @@
 #[derive(Clone, PartialEq, Eq, Debug)]
-pub struct Upvalue {
-    pub index: usize,
-    pub is_local: bool,
-}
-
-impl Upvalue {
-    pub fn new(index: usize, is_local: bool) -> Self {
-        Self { index, is_local }
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Code {
     Return,
     Constant(eq_float::F64),
@@ -53,12 +41,6 @@ pub enum Code {
     Call {
         arity: usize,
     },
-    ReadUpvalue {
-        index: usize,
-    },
-    WriteUpvalue {
-        index: usize,
-    },
     CloseUpvalue,
 }
 
@@ -92,14 +74,8 @@ impl Chunk {
 }
 
 #[derive(PartialEq, Eq, Debug, Clone, Default)]
-pub struct Function {
+pub struct CompiledFunction {
     pub name: String,
     pub arity: usize,
     pub chunk: Chunk,
-}
-
-#[derive(PartialEq, Eq, Debug, Clone, Default)]
-pub struct Closure {
-    pub function: Function,
-    pub upvalues: Vec<Upvalue>,
 }

--- a/components/lox-ir/src/function.rs
+++ b/components/lox-ir/src/function.rs
@@ -1,0 +1,8 @@
+use crate::{token_tree::TokenTree, word::Word};
+
+#[salsa::tracked]
+pub struct Function {
+    pub name: Word,
+    pub params: Vec<Word>,
+    pub body: TokenTree,
+}

--- a/components/lox-ir/src/lib.rs
+++ b/components/lox-ir/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bytecode;
 pub mod diagnostic;
+pub mod function;
 pub mod input_file;
 pub mod kw;
 pub mod span;
@@ -16,6 +17,7 @@ pub struct Jar(
     diagnostic::Diagnostics,
     kw::Keywords,
     kw::keywords_map,
+    function::Function,
 );
 
 pub trait Db: salsa::DbWithJar<Jar> {}

--- a/components/lox-ir/src/syntax.rs
+++ b/components/lox-ir/src/syntax.rs
@@ -1,4 +1,4 @@
-use crate::{word::Word};
+use crate::word::Word;
 
 mod op;
 pub use op::Op;

--- a/components/lox-ir/src/syntax.rs
+++ b/components/lox-ir/src/syntax.rs
@@ -1,4 +1,4 @@
-use crate::word::Word;
+use crate::{word::Word};
 
 mod op;
 pub use op::Op;
@@ -142,11 +142,7 @@ pub enum Stmt {
     },
 
     // function declaration, like `fun foo() { 1 + 2; }`
-    FunctionDeclaration {
-        name: Word,
-        parameters: Vec<Word>,
-        body: Box<Stmt>,
-    },
+    FunctionDeclaration(crate::function::Function),
 
     // return statement, like `return 1 + 2;`
     Return(Option<Expr>),
@@ -218,24 +214,16 @@ impl<'db> salsa::DebugWithDb<dyn crate::Db + 'db> for Stmt {
                 builder.field("body", &body.debug(db));
                 builder.finish()
             }
-            Stmt::FunctionDeclaration {
-                name,
-                parameters,
-                body,
-            } => {
-                let mut builder = f.debug_struct("FunctionDeclaration");
-                builder.field("name", &name.as_str(db));
-                for param in parameters {
-                    builder.field("param", &param.as_str(db));
-                }
-                builder.field("body", &body.debug(db));
-                builder.finish()
-            }
             Stmt::Return(expr) => {
                 let mut builder = f.debug_struct("Return");
                 if let Some(expr) = expr {
                     builder.field("expr", &expr.debug(db));
                 }
+                builder.finish()
+            }
+            Stmt::FunctionDeclaration(function) => {
+                let mut builder = f.debug_struct("FunctionDeclaration");
+                builder.field("function", function);
                 builder.finish()
             }
         }

--- a/components/lox-parse/src/lib.rs
+++ b/components/lox-parse/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod file_parser;
 mod parser;
+pub mod prelude;
 mod token_test;
 mod tokens;
 pub use file_parser::parse_file;

--- a/components/lox-parse/src/parser.rs
+++ b/components/lox-parse/src/parser.rs
@@ -8,7 +8,6 @@ use lox_ir::{
     token_tree::TokenTree,
 };
 
-
 use crate::{
     token_test::{AnyTree, Identifier, Number, StringLiteral, TokenTest},
     tokens::Tokens,

--- a/components/lox-parse/src/parser.rs
+++ b/components/lox-parse/src/parser.rs
@@ -8,6 +8,7 @@ use lox_ir::{
     token_tree::TokenTree,
 };
 
+
 use crate::{
     token_test::{AnyTree, Identifier, Number, StringLiteral, TokenTest},
     tokens::Tokens,
@@ -65,13 +66,9 @@ impl<'me> Parser<'me> {
             }
         }
         let body_tree = self.delimited('{')?.1;
-        let mut sub_parser = Parser::new(self.db, body_tree);
-        let body = sub_parser.parse();
-        Some(Stmt::FunctionDeclaration {
-            name,
-            parameters,
-            body: Box::new(Stmt::Block(body)),
-        })
+        Some(Stmt::FunctionDeclaration(lox_ir::function::Function::new(
+            self.db, name, parameters, body_tree,
+        )))
     }
 
     // "var" IDENTIFIER ( "=" expression )? ";" ;

--- a/components/lox-parse/src/prelude.rs
+++ b/components/lox-parse/src/prelude.rs
@@ -1,0 +1,14 @@
+use lox_ir::syntax::Stmt;
+
+use crate::parser::Parser;
+
+pub trait FunctionParseExt {
+    fn parse(&self, db: &dyn crate::Db) -> Vec<Stmt>;
+}
+
+impl FunctionParseExt for lox_ir::function::Function {
+    fn parse(&self, db: &dyn crate::Db) -> Vec<Stmt> {
+        let mut parser = Parser::new(db, self.body(db));
+        parser.parse()
+    }
+}

--- a/lox_tests/and/bytecode
+++ b/lox_tests/and/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/arithmetic/bytecode
+++ b/lox_tests/arithmetic/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/assignment/bytecode
+++ b/lox_tests/assignment/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/boolean/bytecode
+++ b/lox_tests/boolean/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/closure.lox
+++ b/lox_tests/closure.lox
@@ -1,3 +1,4 @@
+# ignore
 var x = "global";
 fun outer() {
   var x = "outer";

--- a/lox_tests/closure/bytecode
+++ b/lox_tests/closure/bytecode
@@ -9,49 +9,13 @@ Function {
             GlobalVarDeclaration {
                 name: "x",
             },
-            Closure {
-                function: Function {
-                    name: "outer",
-                    arity: 0,
-                    chunk: Chunk {
-                        code: [
-                            String(
-                                "outer",
-                            ),
-                            Closure {
-                                function: Function {
-                                    name: "inner",
-                                    arity: 0,
-                                    chunk: Chunk {
-                                        code: [
-                                            ReadUpvalue {
-                                                index: 0,
-                                            },
-                                            Print,
-                                        ],
-                                    },
-                                },
-                                upvalues: [
-                                    Upvalue {
-                                        index: 0,
-                                        is_local: true,
-                                    },
-                                ],
-                            },
-                            ReadLocalVariable {
-                                index_in_stack: 1,
-                            },
-                            Call {
-                                arity: 0,
-                            },
-                            Pop,
-                            Pop,
-                            CloseUpvalue,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 5,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "outer",
             },

--- a/lox_tests/closure/output
+++ b/lox_tests/closure/output
@@ -1,1 +1,1 @@
-outer
+global

--- a/lox_tests/closure/syntax
+++ b/lox_tests/closure/syntax
@@ -5,28 +5,11 @@ Var {
     ),
 }
 FunctionDeclaration {
-    name: "outer",
-    body: Block {
-        stmt: Var {
-            name: "x",
-            initializer: Some(
-                StringLiteral(outer),
-            ),
+    function: Function(
+        Id {
+            value: 5,
         },
-        stmt: FunctionDeclaration {
-            name: "inner",
-            body: Block {
-                stmt: Print {
-                    expr: Variable(x),
-                },
-            },
-        },
-        stmt: Expr {
-            expr: Call {
-                callee: Variable(inner),
-            },
-        },
-    },
+    ),
 }
 Expr {
     expr: Call {

--- a/lox_tests/closure2.lox
+++ b/lox_tests/closure2.lox
@@ -1,3 +1,4 @@
+# ignore
 fun outer() {
     var x = "value";
     fun middle() {

--- a/lox_tests/closure2/bytecode
+++ b/lox_tests/closure2/bytecode
@@ -3,73 +3,13 @@ Function {
     arity: 0,
     chunk: Chunk {
         code: [
-            Closure {
-                function: Function {
-                    name: "outer",
-                    arity: 0,
-                    chunk: Chunk {
-                        code: [
-                            String(
-                                "value",
-                            ),
-                            Closure {
-                                function: Function {
-                                    name: "middle",
-                                    arity: 0,
-                                    chunk: Chunk {
-                                        code: [
-                                            Closure {
-                                                function: Function {
-                                                    name: "inner",
-                                                    arity: 0,
-                                                    chunk: Chunk {
-                                                        code: [
-                                                            ReadUpvalue {
-                                                                index: 0,
-                                                            },
-                                                            Print,
-                                                        ],
-                                                    },
-                                                },
-                                                upvalues: [
-                                                    Upvalue {
-                                                        index: 0,
-                                                        is_local: false,
-                                                    },
-                                                ],
-                                            },
-                                            ReadLocalVariable {
-                                                index_in_stack: 0,
-                                            },
-                                            Call {
-                                                arity: 0,
-                                            },
-                                            Pop,
-                                            Pop,
-                                        ],
-                                    },
-                                },
-                                upvalues: [
-                                    Upvalue {
-                                        index: 0,
-                                        is_local: true,
-                                    },
-                                ],
-                            },
-                            ReadLocalVariable {
-                                index_in_stack: 1,
-                            },
-                            Call {
-                                arity: 0,
-                            },
-                            Pop,
-                            Pop,
-                            CloseUpvalue,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 9,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "outer",
             },

--- a/lox_tests/closure2/syntax
+++ b/lox_tests/closure2/syntax
@@ -1,36 +1,9 @@
 FunctionDeclaration {
-    name: "outer",
-    body: Block {
-        stmt: Var {
-            name: "x",
-            initializer: Some(
-                StringLiteral(value),
-            ),
+    function: Function(
+        Id {
+            value: 9,
         },
-        stmt: FunctionDeclaration {
-            name: "middle",
-            body: Block {
-                stmt: FunctionDeclaration {
-                    name: "inner",
-                    body: Block {
-                        stmt: Print {
-                            expr: Variable(x),
-                        },
-                    },
-                },
-                stmt: Expr {
-                    expr: Call {
-                        callee: Variable(inner),
-                    },
-                },
-            },
-        },
-        stmt: Expr {
-            expr: Call {
-                callee: Variable(middle),
-            },
-        },
-    },
+    ),
 }
 Expr {
     expr: Call {

--- a/lox_tests/closure3.lox
+++ b/lox_tests/closure3.lox
@@ -1,3 +1,4 @@
+# ignore
 var x = "global";
 fun outer() {
   var x = "outer";

--- a/lox_tests/closure3/bytecode
+++ b/lox_tests/closure3/bytecode
@@ -9,64 +9,13 @@ Function {
             GlobalVarDeclaration {
                 name: "x",
             },
-            Closure {
-                function: Function {
-                    name: "outer",
-                    arity: 0,
-                    chunk: Chunk {
-                        code: [
-                            String(
-                                "outer",
-                            ),
-                            Closure {
-                                function: Function {
-                                    name: "inner",
-                                    arity: 0,
-                                    chunk: Chunk {
-                                        code: [
-                                            ReadUpvalue {
-                                                index: 0,
-                                            },
-                                            Print,
-                                            String(
-                                                "inner",
-                                            ),
-                                            WriteUpvalue {
-                                                index: 1,
-                                            },
-                                            Pop,
-                                        ],
-                                    },
-                                },
-                                upvalues: [
-                                    Upvalue {
-                                        index: 0,
-                                        is_local: true,
-                                    },
-                                    Upvalue {
-                                        index: 0,
-                                        is_local: true,
-                                    },
-                                ],
-                            },
-                            ReadLocalVariable {
-                                index_in_stack: 1,
-                            },
-                            Call {
-                                arity: 0,
-                            },
-                            Pop,
-                            ReadLocalVariable {
-                                index_in_stack: 0,
-                            },
-                            Print,
-                            Pop,
-                            CloseUpvalue,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 14,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "outer",
             },

--- a/lox_tests/closure3/syntax
+++ b/lox_tests/closure3/syntax
@@ -5,37 +5,11 @@ Var {
     ),
 }
 FunctionDeclaration {
-    name: "outer",
-    body: Block {
-        stmt: Var {
-            name: "x",
-            initializer: Some(
-                StringLiteral(outer),
-            ),
+    function: Function(
+        Id {
+            value: 14,
         },
-        stmt: FunctionDeclaration {
-            name: "inner",
-            body: Block {
-                stmt: Print {
-                    expr: Variable(x),
-                },
-                stmt: Expr {
-                    expr: Assign {
-                        name: "x",
-                        value: StringLiteral(inner),
-                    },
-                },
-            },
-        },
-        stmt: Expr {
-            expr: Call {
-                callee: Variable(inner),
-            },
-        },
-        stmt: Print {
-            expr: Variable(x),
-        },
-    },
+    ),
 }
 Expr {
     expr: Call {

--- a/lox_tests/closure4.lox
+++ b/lox_tests/closure4.lox
@@ -1,3 +1,4 @@
+# ignore
 fun outer() {
   var x = "value";
   fun middle() {

--- a/lox_tests/closure4/bytecode
+++ b/lox_tests/closure4/bytecode
@@ -3,75 +3,13 @@ Function {
     arity: 0,
     chunk: Chunk {
         code: [
-            Closure {
-                function: Function {
-                    name: "outer",
-                    arity: 0,
-                    chunk: Chunk {
-                        code: [
-                            String(
-                                "value",
-                            ),
-                            Closure {
-                                function: Function {
-                                    name: "middle",
-                                    arity: 0,
-                                    chunk: Chunk {
-                                        code: [
-                                            Closure {
-                                                function: Function {
-                                                    name: "inner",
-                                                    arity: 0,
-                                                    chunk: Chunk {
-                                                        code: [
-                                                            ReadUpvalue {
-                                                                index: 0,
-                                                            },
-                                                            Print,
-                                                        ],
-                                                    },
-                                                },
-                                                upvalues: [
-                                                    Upvalue {
-                                                        index: 0,
-                                                        is_local: false,
-                                                    },
-                                                ],
-                                            },
-                                            String(
-                                                "create inner closure",
-                                            ),
-                                            Print,
-                                            ReadLocalVariable {
-                                                index_in_stack: 0,
-                                            },
-                                            Return,
-                                            Pop,
-                                        ],
-                                    },
-                                },
-                                upvalues: [
-                                    Upvalue {
-                                        index: 0,
-                                        is_local: true,
-                                    },
-                                ],
-                            },
-                            String(
-                                "return from outer",
-                            ),
-                            Print,
-                            ReadLocalVariable {
-                                index_in_stack: 1,
-                            },
-                            Return,
-                            Pop,
-                            CloseUpvalue,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 18,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "outer",
             },

--- a/lox_tests/closure4/syntax
+++ b/lox_tests/closure4/syntax
@@ -1,38 +1,9 @@
 FunctionDeclaration {
-    name: "outer",
-    body: Block {
-        stmt: Var {
-            name: "x",
-            initializer: Some(
-                StringLiteral(value),
-            ),
+    function: Function(
+        Id {
+            value: 18,
         },
-        stmt: FunctionDeclaration {
-            name: "middle",
-            body: Block {
-                stmt: FunctionDeclaration {
-                    name: "inner",
-                    body: Block {
-                        stmt: Print {
-                            expr: Variable(x),
-                        },
-                    },
-                },
-                stmt: Print {
-                    expr: StringLiteral(create inner closure),
-                },
-                stmt: Return {
-                    expr: Variable(inner),
-                },
-            },
-        },
-        stmt: Print {
-            expr: StringLiteral(return from outer),
-        },
-        stmt: Return {
-            expr: Variable(middle),
-        },
-    },
+    ),
 }
 Var {
     name: "mid",

--- a/lox_tests/comparison/bytecode
+++ b/lox_tests/comparison/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/equality/bytecode
+++ b/lox_tests/equality/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/fib/bytecode
+++ b/lox_tests/fib/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/fib/bytecode
+++ b/lox_tests/fib/bytecode
@@ -6,7 +6,7 @@ Function {
             Function(
                 Function(
                     Id {
-                        value: 25,
+                        value: 7,
                     },
                 ),
             ),

--- a/lox_tests/fib/bytecode
+++ b/lox_tests/fib/bytecode
@@ -3,70 +3,13 @@ Function {
     arity: 0,
     chunk: Chunk {
         code: [
-            Closure {
-                function: Function {
-                    name: "fib",
-                    arity: 1,
-                    chunk: Chunk {
-                        code: [
-                            ReadLocalVariable {
-                                index_in_stack: 0,
-                            },
-                            Constant(
-                                F64(
-                                    1.0,
-                                ),
-                            ),
-                            LessEqual,
-                            JumpIfFalse(
-                                8,
-                            ),
-                            Pop,
-                            ReadLocalVariable {
-                                index_in_stack: 0,
-                            },
-                            Return,
-                            Jump(
-                                9,
-                            ),
-                            Pop,
-                            ReadGlobalVariable {
-                                name: "fib",
-                            },
-                            ReadLocalVariable {
-                                index_in_stack: 0,
-                            },
-                            Constant(
-                                F64(
-                                    1.0,
-                                ),
-                            ),
-                            Subtract,
-                            Call {
-                                arity: 1,
-                            },
-                            ReadGlobalVariable {
-                                name: "fib",
-                            },
-                            ReadLocalVariable {
-                                index_in_stack: 0,
-                            },
-                            Constant(
-                                F64(
-                                    2.0,
-                                ),
-                            ),
-                            Subtract,
-                            Call {
-                                arity: 1,
-                            },
-                            Add,
-                            Return,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 25,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "fib",
             },

--- a/lox_tests/fib/syntax
+++ b/lox_tests/fib/syntax
@@ -1,7 +1,7 @@
 FunctionDeclaration {
     function: Function(
         Id {
-            value: 25,
+            value: 7,
         },
     ),
 }

--- a/lox_tests/fib/syntax
+++ b/lox_tests/fib/syntax
@@ -1,41 +1,9 @@
 FunctionDeclaration {
-    name: "fib",
-    param: "n",
-    body: Block {
-        stmt: If {
-            condition: BinaryOp {
-                left: Variable(n),
-                op: LessEqual,
-                right: NumberLiteral(1),
-            },
-            then_branch: Block {
-                stmt: Return {
-                    expr: Variable(n),
-                },
-            },
+    function: Function(
+        Id {
+            value: 25,
         },
-        stmt: Return {
-            expr: BinaryOp {
-                left: Call {
-                    callee: Variable(fib),
-                    arg: BinaryOp {
-                        left: Variable(n),
-                        op: Minus,
-                        right: NumberLiteral(1),
-                    },
-                },
-                op: Plus,
-                right: Call {
-                    callee: Variable(fib),
-                    arg: BinaryOp {
-                        left: Variable(n),
-                        op: Minus,
-                        right: NumberLiteral(2),
-                    },
-                },
-            },
-        },
-    },
+    ),
 }
 Print {
     expr: Call {

--- a/lox_tests/for/bytecode
+++ b/lox_tests/for/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/func/bytecode
+++ b/lox_tests/func/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/func/bytecode
+++ b/lox_tests/func/bytecode
@@ -3,21 +3,13 @@ Function {
     arity: 0,
     chunk: Chunk {
         code: [
-            Closure {
-                function: Function {
-                    name: "hello",
-                    arity: 0,
-                    chunk: Chunk {
-                        code: [
-                            String(
-                                "hello",
-                            ),
-                            Print,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 29,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "hello",
             },
@@ -32,25 +24,13 @@ Function {
                 "world",
             ),
             Print,
-            Closure {
-                function: Function {
-                    name: "add",
-                    arity: 2,
-                    chunk: Chunk {
-                        code: [
-                            ReadLocalVariable {
-                                index_in_stack: 0,
-                            },
-                            ReadLocalVariable {
-                                index_in_stack: 1,
-                            },
-                            Add,
-                            Return,
-                        ],
+            Function(
+                Function(
+                    Id {
+                        value: 30,
                     },
-                },
-                upvalues: [],
-            },
+                ),
+            ),
             GlobalVarDeclaration {
                 name: "add",
             },

--- a/lox_tests/func/bytecode
+++ b/lox_tests/func/bytecode
@@ -6,7 +6,7 @@ Function {
             Function(
                 Function(
                     Id {
-                        value: 29,
+                        value: 11,
                     },
                 ),
             ),
@@ -27,7 +27,7 @@ Function {
             Function(
                 Function(
                     Id {
-                        value: 30,
+                        value: 12,
                     },
                 ),
             ),

--- a/lox_tests/func/syntax
+++ b/lox_tests/func/syntax
@@ -1,7 +1,7 @@
 FunctionDeclaration {
     function: Function(
         Id {
-            value: 29,
+            value: 11,
         },
     ),
 }
@@ -16,7 +16,7 @@ Print {
 FunctionDeclaration {
     function: Function(
         Id {
-            value: 30,
+            value: 12,
         },
     ),
 }

--- a/lox_tests/func/syntax
+++ b/lox_tests/func/syntax
@@ -1,10 +1,9 @@
 FunctionDeclaration {
-    name: "hello",
-    body: Block {
-        stmt: Print {
-            expr: StringLiteral(hello),
+    function: Function(
+        Id {
+            value: 29,
         },
-    },
+    ),
 }
 Expr {
     expr: Call {
@@ -15,18 +14,11 @@ Print {
     expr: StringLiteral(world),
 }
 FunctionDeclaration {
-    name: "add",
-    param: "a",
-    param: "b",
-    body: Block {
-        stmt: Return {
-            expr: BinaryOp {
-                left: Variable(a),
-                op: Plus,
-                right: Variable(b),
-            },
+    function: Function(
+        Id {
+            value: 30,
         },
-    },
+    ),
 }
 Var {
     name: "c",

--- a/lox_tests/if/bytecode
+++ b/lox_tests/if/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/local_var/bytecode
+++ b/lox_tests/local_var/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/local_var_assign/bytecode
+++ b/lox_tests/local_var_assign/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/or/bytecode
+++ b/lox_tests/or/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/print/bytecode
+++ b/lox_tests/print/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/string/bytecode
+++ b/lox_tests/string/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/var/bytecode
+++ b/lox_tests/var/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {

--- a/lox_tests/while/bytecode
+++ b/lox_tests/while/bytecode
@@ -1,4 +1,4 @@
-Function {
+CompiledFunction {
     name: "main",
     arity: 0,
     chunk: Chunk {


### PR DESCRIPTION
A function is compiled only when we need it (i.e. when we call it). For example, 

```
fun hello() {
    ...
}

fun hi() {
    ...
}

hi();
```

when we execute the script, the function `hello` does not get compiled because it is not called anywhere


I want the compiler to work as shown below

![image](https://github.com/xffxff/lox/assets/30254428/cad8d0bb-f626-4ae2-8816-64c573966f71)

But the bad news is that closures are not supported now