### PR TITLE
use relative paths in diagnostics for test cases

### DIFF
--- a/lox_tests/diagnostics/error_in_function/output
+++ b/lox_tests/diagnostics/error_in_function/output
@@ -1,5 +1,5 @@
 Error: expected `;`
-   ╭─[/home/zhoufan/workspace/rust/lox/lox_tests/diagnostics/error_in_function.lox:2:18]
+   ╭─[lox_tests/diagnostics/error_in_function.lox:2:18]
    │
  2 │     print "hello"
    │                  ┬  

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,11 +81,18 @@ impl TestCase {
         }
     }
 
+    // relative path relative to crate root
+    fn relative_path(path: &Path) -> PathBuf {
+        let crate_root_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        path.strip_prefix(crate_root_dir).unwrap().to_owned()
+    }
+
     fn test(self, db: &Database) {
         print!("test {} ... ", self.lox.display());
+        let relative_path = TestCase::relative_path(&self.lox);
         let input_file = InputFile::new(
             db,
-            Word::intern(db, self.lox.to_str().unwrap()),
+            Word::intern(db, relative_path.to_str().unwrap()),
             self.text.clone(),
         );
 


### PR DESCRIPTION
Use relative paths in diagnostics for test cases to ensure CI  passes. This is because absolute paths will differ between my local environment and the CI environment, potentially causing issues.

![image](https://github.com/xffxff/lox/assets/30254428/c6335d8e-a6ee-4e88-9cee-dc62d6a045d9)
